### PR TITLE
Update HIP-0003: DNS version

### DIFF
--- a/HIP-0003.md
+++ b/HIP-0003.md
@@ -87,6 +87,22 @@ Note: there's no point in adding the public key in the response from the Provide
 
 Once all verifications are complete, the Service can use the `domain` to identify the current User.
 
+### Diagram
+
+```mermaid
+sequenceDiagram
+    User->>+Service: Login as "example"
+    Service->>+DNS: Get TXT Records
+    DNS->>-Service: All TXT records
+    Service->>Service: Filter AUTH: record
+    Service->>+Provider: Auth request redirect
+    Provider->>+User: Ask to confirm
+    User->>-Provider: Confirms
+    Provider->>-Service: Callback
+    Service->>Service: Validate signature
+    Service->>-User: Initiate Session
+```
+
 ## Consideration
 
 This proposal does not force the domain name to be a TLD. Users could authenticate themselves with `support.example` for instance.

--- a/HIP-0003.md
+++ b/HIP-0003.md
@@ -40,8 +40,10 @@ This also means that, once the User chooses a Provider and is onboarded, the Use
 ### Exposing the public key and provider URL
 
 The public key and Provider URL should be exposed via DNS TXT record.
-The record should have the following format: `HIP3:<public key>:<provider url>`
-Example: `HIP3:04e57a5d7f2a3b3c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff:https://example.com`
+The record should have the following format: `AUTH:<public key>:<provider url>`
+Example: `AUTH:04e57a5d7f2a3b3c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff:https://example.com`
+
+Note: the Provider URL could have a custom protocol, or trigger a deep-link to a browser extension or another software running locally (like a wallet)
 
 ### Authentication request
 
@@ -76,7 +78,7 @@ Example: `https://service.com/callback?session=ABC&domain=example&challenge=446b
 
 When the Service is called via its callback URL, it should:
 
-1. Retrieve the TXT DNS record prefixed with `HIP3:` and from that extract the public key.
+1. Retrieve the TXT DNS record prefixed with `AUTH:` and from that extract the public key.
 2. Verify the challenge is identical from the request.
 3. Verify the signature is valid (using the public key from step 1).
    The Service should reject the authentication request if any of the above fails.

--- a/HIP-0003.md
+++ b/HIP-0003.md
@@ -4,92 +4,89 @@
 Number:  HIP-0003
 Title:   Authentication using Handshake name
 Type:    Informational
-Status:  Draft
-Authors: Fernando Falci <https://iamfernando/>
+Status:  Final
+Authors: Fernando Falci <falci>
 Created: 2020-10-25
 ```
 
 ## Abstract
 
-This HIP describe how to authenticate a user using his/her Handshake name.
+This HIP describe how to authenticate a user using their Handshake name.
 
 ## Motivation
 
-Many websites need to identify the user and proof he/she owns a Handshake name. Many other websites simply need to identify users, which forces them to go into a process to pick a unique username that most of the time can't be consistent across different apps. By using Handshake names as username it allows both: proof ownership of the name and consistent username across unrelated apps.
+Many websites need to identify the user and prove they own a Handshake name. Other websites simply need to identify users, which forces the user to enter a process of picking a unique username that most of the time can't be consistent across different apps. Using Handshake names as usernames allows both to happen: prove ownership of a name and have a consistent username across unrelated apps.
 
-## Protocol
+## Protocol Overview
 
-The basics of this protocol consist of a public and private ECDSA key. The domain exposes the public key via HTTPS request.
+The basics of this protocol consist of a public and private ECDSA key. The domain exposes the public key via DNS record.
 The Service that wants to authenticate the user should provide this user with a unique challenge.
-The User signs the challenge using his/her private key and returns it to the Service, among the public key and the domain name.
-The Service then validates if the challenge is correct and was correct signed. The Service also validates if the domain name indeed exposes that public key.
+The User signs the challenge using their private key and returns it to the Service, among the public key and the domain name.
+The Service then confirms the challenge is correctly signed. The Service also validates if the domain name indeed exposes the public key.
 
 ### Provider
 
 The above-mentioned flow requires an extra piece of software: a user-trusted provider. This provider knows/holds the user's private key. It can run on the client-side, as a browser extension or an installed app; or it can run remotely as a regular web service.
 This provider will respond to the request with the signed challenge sent by the Service.
 
-To be a provider, the Provider needs to register and respond for the [custom protocol](https://html.spec.whatwg.org/#web+-scheme-prefix) `web+hns`.
-
-This protocol will be used by the Service to send authentication challenges.
+The domain should also have a DNS record to define the URL of its Provider.
 
 Assuming that the community will provide different solutions and implementation options, the User will choose one Provider and register it to respond to the custom protocol.
 
 It is outside the context of this HIP to define how the Provider interacts with the User or how the public/private keys should be generated.
 
-This also means that, once the User chooses a Provider and is onboarded, the User won't be able to switch to another provider without replacing its public key. In other words: the User cannot authenticate itself with any Provider, but only with the Provider he/she used to generate the public key.
+This also means that, once the User chooses a Provider and is onboarded, the User won't be able to switch to another provider without replacing its public key. In other words: the User cannot authenticate itself with any Provider, but only with the Provider they used to generate the public key.
 
-### Exposing the public key
+### Exposing the public key and provider URL
 
-The public key should be exposed via HTTPS request to `.well-known/authentication`. For the domain `example` the full URL should be `https://example/.well-known/authentication`.
-
-This url should use a SSL certificate validate with [DANE](https://tools.ietf.org/html/rfc6698) or by a Certificate authority.
+The public key and Provider URL should be exposed via DNS TXT record.
+The record should have the following format: `HIP3:<public key>:<provider url>`
+Example: `HIP3:04e57a5d7f2a3b3c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff:https://example.com`
 
 ### Authentication request
 
-Any Service can create an authentication request. It's a basic `GET` request to `web+hns://authentication/?challenge=<CHALLENGE>&callback=<CALLBACK>`.
+Any Service can create an authentication request. It should send the user to the Provider URL (`GET` request) defining the Challenge and the Callback URL: `<Provider URL>?challenge=<Challenge>&callback=<Callback>`.
 
-| Key            | Type                 | Options                                                                                                                          |
-| -------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| web+hns://     | protocol             | Fixed.                                                                                                                           |
-| authentication | Reserved URL keyword | Fixed.                                                                                                                           |
-| challenge      | querystring          | A 32-characters long string. Hex.                                                                                                |
-| callback       | querystring          | An encoded callback URL. It will be (async) called by the provider with the challenge response. It must be a secure URL (HTTPS). |
+| Key          | Type        | Options                                                                                                                          |
+| ------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Provider URL | DNS         | Based on DNS record.                                                                                                             |
+| challenge    | querystring | A 32-characters long string. Hex.                                                                                                |
+| callback     | querystring | An encoded callback URL. It will be (async) called by the provider with the challenge response. It must be a secure URL (HTTPS). |
+
+Example:
+`https://example.com?challenge=446bcbfd1b0cae7ae75e8afc33b35a5a&callback=https%3A%2F%2Fservice.com%2Fcallback%3Fsession%3DABC
 
 ### Authentication response
 
-It's a Provider's decision on how to identify and authenticate the user with the Provider.
+It's a Provider's decision on how to identify and authenticate the User.
 
-Once the provider identifies the User, it can sign the challenge using the User's private key and call the Service using the provided callback URL in a `GET` request.
+Once the Provider identifies the User, it can sign the challenge using the User's private key and call the Service using the provided callback URL in a GET request.
 
-The following query string should be added to the callback URL:
+The following query string should be appended to the callback URL:
 
 | Key       | Options                                     |
 | --------- | ------------------------------------------- |
-| domain    | The domain name that will identify the user |
+| domain    | The domain name that will identify the User |
 | challenge | The same challenge sent by the Service      |
 | signature | The signed challenge                        |
 
+Example: `https://service.com/callback?session=ABC&domain=example&challenge=446bcbfd1b0cae7ae75e8afc33b35a5a&signature=3045022100a3b5c7d9e8f123456789abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcde02207f8e9d6c4b3a2f1e0d9c8b7a6f5e4d3c2b1a0987654321fedcba9876543210f`
+
 ### Handling a response
 
-When the Service is called via its callback URL, it should do the following verifications:
+When the Service is called via its callback URL, it should:
 
--   Check if the domain exposes a public key.
--   Check if the challenge is the same challenge from the request.
--   Verify if the signature is valid (using the already retrieved public key).
-
-The Service should reject the authentication request if any of the above fails.
+1. Retrieve the TXT DNS record prefixed with `HIP3:` and from that extract the public key.
+2. Verify the challenge is identical from the request.
+3. Verify the signature is valid (using the public key from step 1).
+   The Service should reject the authentication request if any of the above fails.
 
 Note: there's no point in adding the public key in the response from the Provider to the Service since it won't be trusted.
 
-Once all verifications are complete, the Service can use the `domain` to identify the current user.
+Once all verifications are complete, the Service can use the `domain` to identify the current User.
 
 ## Consideration
 
 This proposal does not force the domain name to be a TLD. Users could authenticate themselves with `support.example` for instance.
 
-There's no need to be strict with a Handshake domain name. Users could authenticate themselves with `example.com` for instance.
-
-## Reference
-
-[DANE](https://tools.ietf.org/html/rfc6698)
+Additionally, there's no need to be strict with a Handshake domain name. Users could authenticate themselves with `example.com`.

--- a/HIP-0003.md
+++ b/HIP-0003.md
@@ -87,6 +87,13 @@ Note: there's no point in adding the public key in the response from the Provide
 
 Once all verifications are complete, the Service can use the `domain` to identify the current User.
 
+### Security Considerations
+
+The user domain should have DNSSEC enabled.
+Both URLs, provider and callback, should be HTTPS, except when the provider is running locally.
+The Service should include an unique challenge and don't accept the same challenge twice to avoid replay attacks.
+The Service should define an internal timeout for the challenge.
+
 ### Diagram
 
 ```mermaid


### PR DESCRIPTION
Revise HIP-0003 to finalize the status and enhance clarity in the authentication protocol using Handshake names, emphasizing the use of DNS records for public key exposure and provider URL.